### PR TITLE
Add support for nodeSelector in qryn-deployment.yaml

### DIFF
--- a/templates/qryn-deployment.yaml
+++ b/templates/qryn-deployment.yaml
@@ -17,6 +17,10 @@ spec:
       automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
+      {{ end }}
       containers:
       - image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         name: {{ include "qryn-helm.fullname" . }}

--- a/values.yaml
+++ b/values.yaml
@@ -28,10 +28,14 @@ livenessProbe:
   endpoint: "/metrics"
 
 podAnnotations: {}
+
 # podLabels: {}
 podLabels:
   - qryn
+
 nodeSelector: {}
+# nodeSelector:
+#   kubernetes.io/os: linux
 
 tolerations: []
 


### PR DESCRIPTION
The current version of `qryn-deployment.yaml` does not do anything with the `nodeSelector` value. Therefore, it is not possible to specify what kind of node qryn should be installed on. For example, in the case of a hybrid Linux+Windows cluster, it is possible that the qryn pod is deployed on a Windows node which are not supported at the time of writing.

In addition to the change in `qryn-deployment.yaml`, I have also added an example of a common use-case for the `nodeSelector` value in `values.yaml`