### PR TITLE
fix  image pull secret

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -8,8 +8,8 @@ image:
   repository: qxip/qryn
   tag: ""
 
-imagePullSecrets: 
-  nameOverride: ""
+# imagePullSecrets: 
+#   nameOverride: ""
 
 imageCredentials: {}
 #   registry: registry.cluster.local


### PR DESCRIPTION
Fix: "Unable to retrieve some image pull secrets (qryn-write-test-regcred); attempting to pull the image may not succeed."